### PR TITLE
Add bash -x option to add more debugging info

### DIFF
--- a/pipelines/hyperkube-pr/Jenkinsfile
+++ b/pipelines/hyperkube-pr/Jenkinsfile
@@ -1,4 +1,4 @@
-def bash(String cmd) { sh("#/usr/bin/env bash\nset -euo pipefail\n${cmd}") }
+def bash(String cmd) { sh("#/usr/bin/env bash\nset -exuo pipefail\n${cmd}") }
 
 podTemplate(label: 'hyperkube-build',
   containers: [containerTemplate(name: 'build', image: 'quay.io/coreos/hyperkube-builder:0.2', ttyEnabled: true, command: 'cat')],

--- a/pipelines/hyperkube-release/Jenkinsfile
+++ b/pipelines/hyperkube-release/Jenkinsfile
@@ -1,4 +1,4 @@
-def bash(String cmd) { sh("#/usr/bin/env bash\nset -euo pipefail\n${cmd}") }
+def bash(String cmd) { sh("#/usr/bin/env bash\nset -exuo pipefail\n${cmd}") }
 
 podTemplate(label: 'hyperkube-build',
   containers: [containerTemplate(name: 'build', image: 'quay.io/coreos/hyperkube-builder:0.2', ttyEnabled: true, command: 'cat')],

--- a/scripts/1-hyperkube-release.sh
+++ b/scripts/1-hyperkube-release.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -euo pipefail
+set -exuo pipefail
 
 echo "RELEASE_TAG=${RELEASE_TAG}"
 echo "PATCHES_FROM=${PATCHES_FROM}"


### PR DESCRIPTION
The `1-hyperkube-release.sh` script is failing in Jenkins, this is to add more debugging info so I know exactly where it's failing.